### PR TITLE
lack of first character package name & class filename in report xml

### DIFF
--- a/ProfdataToCobertura/SummaryCoverage.swift
+++ b/ProfdataToCobertura/SummaryCoverage.swift
@@ -30,7 +30,7 @@ extension String {
                         print("Processing \(path)")
                     }
                     var startIndex = path.startIndex
-                    startIndex = startIndex.advancedBy(sourcePath.startIndex.distanceTo(sourcePath.endIndex)+1)
+                    startIndex = startIndex.advancedBy(sourcePath.startIndex.distanceTo(sourcePath.endIndex))
                     path = path.substringWithRange(Range(start:startIndex, end:path.endIndex.predecessor()))
 
                     groupLines.removeAtIndex(0) // remove path

--- a/ProfdataToCoberturaTests/FileCoverageTests.swift
+++ b/ProfdataToCoberturaTests/FileCoverageTests.swift
@@ -12,45 +12,45 @@ import XCTest
 class ClassCoverageTests: XCTestCase {
 
     func testMultipleRelativePathComponent() {
-        let classCoverage = ClassCoverage(path:"a/b/c", lines:[])
+        let classCoverage = ClassCoverage(path:"a/b/c", lines:[], verbose:false)
         XCTAssertEqual("a/b/c", classCoverage.path)
         XCTAssertEqual(["a","b"], classCoverage.pathComponents)
         XCTAssertEqual("c", classCoverage.filename)
     }
 
     func testMultipleFullPathComponent() {
-        let classCoverage = ClassCoverage(path:"/a/b/c", lines:[])
+        let classCoverage = ClassCoverage(path:"/a/b/c", lines:[], verbose:false)
         XCTAssertEqual("/a/b/c", classCoverage.path)
         XCTAssertEqual(["a","b"], classCoverage.pathComponents)
         XCTAssertEqual("c", classCoverage.filename)
     }
 
     func testSingleRelativePathComponent() {
-        let classCoverage = ClassCoverage(path:"a", lines:[])
+        let classCoverage = ClassCoverage(path:"a", lines:[], verbose:false)
         XCTAssertEqual("a", classCoverage.path)
         XCTAssertEqual([], classCoverage.pathComponents)
         XCTAssertEqual("a", classCoverage.filename)
     }
 
     func testSingleFullPathComponent() {
-        let classCoverage = ClassCoverage(path:"/a", lines:[])
+        let classCoverage = ClassCoverage(path:"/a", lines:[], verbose:false)
         XCTAssertEqual("/a", classCoverage.path)
         XCTAssertEqual([], classCoverage.pathComponents)
         XCTAssertEqual("a", classCoverage.filename)
     }
 
     func testEmptyPathComponent() {
-        let classCoverage = ClassCoverage(path:"", lines:[])
+        let classCoverage = ClassCoverage(path:"", lines:[], verbose:false)
         XCTAssertEqual([], classCoverage.pathComponents)
         XCTAssertNil(classCoverage.filename)
     }
 
     func testSort() {
-        let fc_a = ClassCoverage(path:"/a", lines:[])
-        let fc_a_b = ClassCoverage(path:"/a/b", lines:[])
-        let fc_a_b_c = ClassCoverage(path:"/a/b/c", lines:[])
-        let fc_d = ClassCoverage(path:"/d", lines:[])
-        let fc_d_e_f = ClassCoverage(path:"/d/e/f", lines:[])
+        let fc_a = ClassCoverage(path:"/a", lines:[], verbose:false)
+        let fc_a_b = ClassCoverage(path:"/a/b", lines:[], verbose:false)
+        let fc_a_b_c = ClassCoverage(path:"/a/b/c", lines:[], verbose:false)
+        let fc_d = ClassCoverage(path:"/d", lines:[], verbose:false)
+        let fc_d_e_f = ClassCoverage(path:"/d/e/f", lines:[], verbose:false)
         let classCoverages = [
             fc_d,
             fc_a_b,

--- a/ProfdataToCoberturaTests/PackageCoverageTests.swift
+++ b/ProfdataToCoberturaTests/PackageCoverageTests.swift
@@ -19,9 +19,9 @@ class PackageCoverageTests: XCTestCase {
     }
 
     func testFlatGroup() {
-        let fcA = ClassCoverage(path: "Filename.A", lines: [])
-        let fcB = ClassCoverage(path: "Filename.B", lines: [])
-        let fcC = ClassCoverage(path: "Filename.C", lines: [])
+        let fcA = ClassCoverage(path: "Filename.A", lines: [], verbose:false)
+        let fcB = ClassCoverage(path: "Filename.B", lines: [], verbose:false)
+        let fcC = ClassCoverage(path: "Filename.C", lines: [], verbose:false)
         let classCoverages = [fcA, fcB, fcC]
         let rootPackage = PackageCoverage.toPackageTree(classCoverages)
 
@@ -32,9 +32,9 @@ class PackageCoverageTests: XCTestCase {
     }
 
     func testSingleGroupWithPathComponents() {
-        let fcA = ClassCoverage(path: "/a/b/Filename.A", lines: [])
-        let fcB = ClassCoverage(path: "/a/b/Filename.B", lines: [])
-        let fcC = ClassCoverage(path: "/a/b/Filename.C", lines: [])
+        let fcA = ClassCoverage(path: "/a/b/Filename.A", lines: [], verbose:false)
+        let fcB = ClassCoverage(path: "/a/b/Filename.B", lines: [], verbose:false)
+        let fcC = ClassCoverage(path: "/a/b/Filename.C", lines: [], verbose:false)
         let classCoverages = [fcA, fcB, fcC]
         let rootPackage = PackageCoverage.toPackageTree(classCoverages)
 
@@ -60,9 +60,9 @@ class PackageCoverageTests: XCTestCase {
     }
 
     func testMultipleGroupsWithPathComponents() {
-        let fcA = ClassCoverage(path: "Filename.A", lines: [])
-        let fcB = ClassCoverage(path: "/a/b/c/Filename.B", lines: [])
-        let fcC = ClassCoverage(path: "/d/Filename.C", lines: [])
+        let fcA = ClassCoverage(path: "Filename.A", lines: [], verbose:false)
+        let fcB = ClassCoverage(path: "/a/b/c/Filename.B", lines: [], verbose:false)
+        let fcC = ClassCoverage(path: "/d/Filename.C", lines: [], verbose:false)
         let classCoverages = [fcA, fcB, fcC]
         let rootPackage = PackageCoverage.toPackageTree(classCoverages)
 


### PR DESCRIPTION
lack of first character package name & class filename in report xml like this :

``` xml
<package branch-rate="0.0" complexity="0.0" line-rate="0.0" name="unctions">
            <classes>
                <class branch-rate="0.0" complexity="0.0" line-rate="0.0" filename="unctions/Functions.swift" name="Functions.swift">
```

correct result like this :

``` xml
<package branch-rate="0.0" complexity="0.0" line-rate="0.0" name="Functions">
            <classes>
                <class branch-rate="0.0" complexity="0.0" line-rate="0.0" filename="Functions/Functions.swift" name="Functions.swift">
```
